### PR TITLE
Pass the original shell environment variables to subprocess.run

### DIFF
--- a/xmanager/cloud/docker_lib.py
+++ b/xmanager/cloud/docker_lib.py
@@ -141,7 +141,7 @@ def _build_image_with_docker_command(client: docker.DockerClient,
   if progress:
     command[2:2] = ['--progress', 'plain', '--no-cache']
 
-  subprocess.run(command, check=True, env={'DOCKER_BUILDKIT': '1'})
+  subprocess.run(command, check=True, env={**os.environ, 'DOCKER_BUILDKIT': '1'})
 
 
 def _build_image_with_python_client(client: docker.DockerClient, path: str,

--- a/xmanager/docker/docker_adapter.py
+++ b/xmanager/docker/docker_adapter.py
@@ -149,7 +149,7 @@ class DockerAdapter(object):
       cmd.extend(['-it', '--entrypoint', 'bash', image_id])
     else:
       cmd.extend([image_id] + list(args))
-    subprocess.run(args=cmd, check=True, env=env_vars)
+    subprocess.run(args=cmd, check=True, env={**os.environ, **env_vars})
     return None
 
   def stop_container(self, container_id: str) -> None:


### PR DESCRIPTION
https://github.com/deepmind/xmanager/issues/5 is caused by overwriting environment variables in the subprocess.

When pass the `env` arguments to `subprocess.run`, the parent shell env variable will not be inherited.

example: https://wandbox.org/permlink/aYuTaAD7SAfwCGZQ

In this case, commands in `/usr/local/bin` such as` docker` cannot be resolved because the `PATH` variable is lost. ..
Passing the environment variable of the parent shell to `subprocess.run` may be a workaround for this issue.
The problem with this change is that the results of `docker build` and` docker run` can be affected by the state of the local shell.
In my opinion, the effect can be acceptable.
